### PR TITLE
added GET route to request the block type at a queried location (x, y, z)

### DIFF
--- a/Sources/VaporShell/App/Models/BlockData.swift
+++ b/Sources/VaporShell/App/Models/BlockData.swift
@@ -1,0 +1,16 @@
+import Vapor
+import Fluent
+
+public final class BlockData : Content, Codable {
+    let x : Int
+    let y : Int
+    let z : Int
+    let type : String
+
+    init(_ block:Block) {
+        self.x = block.location.x
+        self.y = block.location.y
+        self.z = block.location.z
+        self.type = block.type
+    }
+}

--- a/Sources/VaporShell/App/routes.swift
+++ b/Sources/VaporShell/App/routes.swift
@@ -21,4 +21,30 @@ func routes(_ app: Application) throws {
     app.get { req in
         return "It works!"
     }
+
+    app.get("getBlock") { req -> BlockData in
+        guard let x = try? req.query.get(Int.self, at: "x") else {
+            throw Abort(.badRequest)
+        }
+        guard let y = try? req.query.get(Int.self, at: "y") else {
+            throw Abort(.badRequest)
+        }
+        guard let z = try? req.query.get(Int.self, at: "z") else {
+            throw Abort(.badRequest)
+        }
+        if  y >= 0 && y < world.Blocks.count {
+            if  x >= 0 && x < world.Blocks[y].count {
+                if  z >= 0 && z < world.Blocks[y][x].count {
+                    let block = world.Blocks[y][x][z]
+                    return BlockData(block)
+                } else {
+                    throw Abort(.badRequest)
+                }
+            } else {
+                throw Abort(.badRequest)
+            }
+        } else {
+            throw Abort(.badRequest)
+        }
+    }
 }


### PR DESCRIPTION
Add functionality to request a block's type at a given location

routing:
.../getBlock?x=Int&y=Int&z=Int